### PR TITLE
Add --user-agent when update_file

### DIFF
--- a/scripts/clash.tool
+++ b/scripts/clash.tool
@@ -2,6 +2,7 @@
 
 scripts=$(realpath $0)
 scripts_dir=$(dirname ${scripts})
+user_agent="ClashForMagisk"
 source /data/clash/clash.config
 
 find_packages_uid() {
@@ -35,8 +36,13 @@ update_file() {
     if [ -f ${file} ] ; then
       mv -f ${file} ${file_bak}
     fi
-    echo "/data/adb/magisk/busybox wget --no-check-certificate ${update_url} -o ${file}"
-    /data/adb/magisk/busybox wget --no-check-certificate ${update_url} -O ${file} 2>&1
+    request="/data/adb/magisk/busybox wget"
+    request+=" --no-check-certificate"
+    request+=" --user-agent ${user_agent}"
+    request+=" -O ${file}"
+    request+=" ${update_url}"
+    echo $request
+    $request 2>&1
     sleep 0.5
     if [ -f "${file}" ] ; then
       echo ""


### PR DESCRIPTION
Some url will check user-agent, It will reject or return a wrong content when the user-agent doesn't contain "Clash"

一些配置链接会检查请求中的user-agent，当不包含Clash或者V2等字眼时，会拒绝访问或者返回错误的内容。