### PR TITLE
fix variable name typo error

### DIFF
--- a/scripts/clash.config
+++ b/scripts/clash.config
@@ -28,7 +28,7 @@ use_premium="false"
 
 update_interval="0 00 * * *"
 # set interval update, info: https://crontab.guru/
-auto_updatesubcript="false"
+auto_updateSubcript="false"
 # setting auto update subcript
 subcript_url="url"
 # url langganan config


### PR DESCRIPTION
https://github.com/taamarin/ClashforMagisk/blob/8134167dc38e9acea351b234167a7f4d81633a83/scripts/clash.tool#L54